### PR TITLE
Add OpenSSF Scorecard, Dependabot and Security Policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+
+version: 2
+updates:
+# Enable version updates for Github Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    reviewers:
+      - "codeplaysoftware/security-managers"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,53 @@
+# Scorecards' GitHub action
+
+name: Scorecard supply-chain security
+on:
+  # For Branch-Protection check. Only the default branch is supported. See
+  # https://github.com/ossf/scorecard/blob/main/docs/checks.md#branch-protection
+  branch_protection_rule:
+  schedule:
+    - cron: '22 13 * * 3'
+  push:
+    branches: [ "master" ]
+
+# Declare default permissions as read only.
+permissions: read-all
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      # Needed to upload the results to code-scanning dashboard.
+      security-events: write
+      # Needed to publish results and get a badge (see publish_results below).
+      id-token: write
+
+    steps:
+      - name: "Checkout code"
+        uses: actions/checkout@d632683dd7b4114ad314bca15554477dd762a938 # v4.2.0
+        with:
+          persist-credentials: false
+
+      - name: "Run analysis"
+        uses: ossf/scorecard-action@62b2cac7ed8198b15735ed49ab1e5cf35480ba46 # v2.4.0
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
+      # format to the repository Actions tab.
+      - name: "Upload artifact"
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: SARIF file
+          path: results.sarif
+          retention-days: 5
+
+      # Upload the results to GitHub's code scanning dashboard (optional).
+      # Commenting out will disable upload of results to your repo's Code Scanning dashboard
+      - name: "Upload to code-scanning"
+        uses: github/codeql-action/upload-sarif@e2b3eafc8d227b0241d48be5f425d47c2d750a13 # v3.26.10
+        with:
+          sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # deploy.sh
 
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/codeplaysoftware/deploy-oneapi/badge)](https://scorecard.dev/viewer/?uri=github.com/codeplaysoftware/deploy-oneapi)
+
 This script will attempt to download and install given versions of the Intel
 oneAPI Basekit using the offline installers. It's designed to work on various
 HPC systems which depend on modulefiles to let users choose which packages

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,8 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a vulnerability or a security issue please fill the security
+advisories form [here](../../security/advisories/new), send an email to
+security@codeplay.com or contact us using the [contact form on our web
+page](https://codeplay.com/company/contact/?q=Report%20Security%20Issue).


### PR DESCRIPTION
This PR adds security tools and policy to the project: 

* Enable OpenSSF Scorecard workflow, add badge to README file:
   Scorecard assesses open source projects for security risks through a series of automated checks. OpenSSF scorecard security scan will run on default branch changes, and periodically on a weekly basis. It will create a report of the project status with recommendations.
* Enable Dependabot for GitHub actions: 
  Dependabot updates will happen once a month. To avoid PR noise to developers, organization level "security managers" team. will receive the notification for review. With current status, only the scorecard workflow will be affected.
* Adds the security policy file for Codeplay open source projects.